### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] 2019-03-11
+### Changed
+- Dropped `composer.lock` from repository
 
 ## [1.0.1] 2018-05-16
 ### Fixed
@@ -12,5 +15,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 1.0.0 - 2018-05-16
 Initial Release
 
-[Unreleased]: https://github.com/owncloud/coding-standard/compare/1.0.1...HEAD
+[Unreleased]: https://github.com/owncloud/coding-standard/compare/1.0.2...HEAD
+[1.0.2]: https://github.com/owncloud/coding-standard/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/owncloud/coding-standard/compare/1.0.0...1.0.1


### PR DESCRIPTION
Release for https://github.com/owncloud/coding-standard/pull/15

This drops the hard pinning for projects to rely on a specific `php-cs-fixer` version 

More discussion on the background here: https://github.com/owncloud/coding-standard/pull/16

- [x] tag github releae => new release on packagist will be available
- [x] merge PR