### PR TITLE
Add fixers for refactorings due to phpunit 7/8 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] 2019-12-03
+### Changed
+- Added fixers for refactorings due to phpunit 7/8 deprecations
+
 ## [1.0.2] 2019-03-11
 ### Changed
 - Dropped `composer.lock` from repository

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "friendsofphp/php-cs-fixer": "^2.12"
+        "friendsofphp/php-cs-fixer": "^2.16"
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -70,8 +70,12 @@ class Config extends BaseConfig {
 			'yoda_style' => [
 				'equal' => false,
 				'identical' => false
-			]
-		];
+			],
+            // phpunit automated refactorings
+            'php_unit_no_expectation_annotation' => true,
+            'php_unit_expectation' => true,
+            'php_unit_dedicate_assert_internal_type' => true
+        ];
 		return $rules;
 	}
 }


### PR DESCRIPTION
See https://github.com/owncloud/core/pull/36501 for description of the `phpunit` deprecations and associated `php-cs-fixer` fixes.

Add these to the regular code-style checks so that people who add new unit tests will realise to use the newer `phpunit` functions/methods...

In `composer.json` require `friendsofphp/php-cs-fixer` `2.16` or later, just to make sure that all the fixers will be available.