### PR TITLE
Pin php-cs-fixer to 2.18.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] 2021-03-22
+### Changed
+- Pin php-cs-fixer to 2.18.3
+
 ## [2.0.0] 2019-12-09
 ### Changed
 - Added fixers for refactorings due to phpunit 7/8 deprecations

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "friendsofphp/php-cs-fixer": "^2.16"
+        "friendsofphp/php-cs-fixer": "2.18.3"
     }
 }


### PR DESCRIPTION
This is a workaround for issue https://github.com/owncloud/core/issues/38563

It will get CI passing in core an oC10 apps repos for now.