### PR TITLE
Use php-cs-fixer major version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] 2021-06-09
+### Changed
+- Use php-cs-fixer 3.0 upwards
+
 ## [2.0.2] 2021-06-09
 ### Changed
 - Use php-cs-fixer 2.19 upwards

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "friendsofphp/php-cs-fixer": "^2.19"
+        "friendsofphp/php-cs-fixer": "^3.0"
     }
 }


### PR DESCRIPTION
Fixes #22 

The release for php-cs-fixer is https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v3.0.0

Upgrade notes for php-cs-fixer are here: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md

This will become coding-standard major release 3.0.0.

That will allow us to update its use in oC10 repos in a controlled manner. (We won't have it "arrive automatically")

The main change that is likely to effect each repo is to rename `.php_cs.dist` to `.php-cs-fixer.dist.php`


