### PR TITLE
Fix declaration of getRules() in Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] 2021-06-09
+### Changed
+- Fix declaration of getRules() in Config
+
 ## [3.0.0] 2021-06-09
 ### Changed
 - Use php-cs-fixer 3.0 upwards

--- a/src/Config.php
+++ b/src/Config.php
@@ -30,7 +30,7 @@ class Config extends BaseConfig {
 		$this->setIndent("\t");
 	}
 
-	public function getRules() {
+	public function getRules(): array {
 		$rules = [
 			'@PSR1' => true,
 			// PSR-2


### PR DESCRIPTION
It needs to be compatible with the parent which now explicitly declares the return type `array`