### PR TITLE
Native function invocation strict false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] 2021-06-10
+### Changed
+- Change native_function_invocation rule so that it is not strict
+
 ## [3.0.1] 2021-06-09
 ### Changed
 - Fix declaration of getRules() in Config

--- a/src/Config.php
+++ b/src/Config.php
@@ -61,7 +61,7 @@ class Config extends BaseConfig {
 			'switch_case_space' => true,
 			'visibility_required' => true,
 			// ownCloud specific
-			'native_function_invocation' => true,
+			'native_function_invocation' => ['strict' => false],
 			'array_syntax' => ['syntax' => 'short'],
 			'combine_consecutive_issets' => true,
 			'combine_consecutive_unsets' => true,


### PR DESCRIPTION
See https://cs.symfony.com/doc/rules/function_notation/native_function_invocation.html

By default `native_function_invocation` only let's you put `\` in front of built-in functions that really get some optimization from doing it. This change turns off this "strict" behavior. So people (and existing code) can have the `\` in front of PHP functions if they like. It should save a lot of forced changes to the existing code-base.