### PR TITLE
pin to php-cs-fixer 3.8.0 to avoid problems with 3.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.7] 2022-07-13
+### Changed
+- pin to php-cs-fixer 3.8.0 to avoid problems with 3.9.3
+
 ## [3.0.6] 2022-07-13
 ### Changed
 - pin to php-cs-fixer 3.9.3 to avoid problems with 3.9.2

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "friendsofphp/php-cs-fixer": "v3.9.3"
+        "friendsofphp/php-cs-fixer": "v3.8.0"
     }
 }


### PR DESCRIPTION
3.9.3 also has problems, so go back to 3.8.0