### PR TITLE
Update changelog for php-cs-fixer 3.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.0.10] 2022-09-12
+## [4.0.0] 2022-11-14
 ### Changed
-- use latest php-cs-fixer 3.11.0
+- use latest php-cs-fixer 3.13.0
 
 ## [3.0.9] 2022-07-16
 ### Changed


### PR DESCRIPTION
The newer minor releases of php-cs-fixer (somewhere in 3.11 or 3.10) now have the style so that blank lines after the `class` line are not allowed. This causes a lot of small "mindless" changes to be needed to source code. But it does seem to be a reasonable thing.

Because it will force these source code updates in repos that use `owncloud/coding-standard`, I am making this a major release version 4.0.0. That will let us implement the changes in a controlled way (rather than having CI suddenly start failing the code-style checks).