### PR TITLE
Bump to php-cs-fixer 3.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.3.0] 2023-07-14
+### Changed
+- use latest php-cs-fixer 3.21.0 (the last version that supports PHP 7.4)
+
 ## [4.2.0] 2023-06-28
 ### Changed
 - use latest php-cs-fixer 3.20.0

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "friendsofphp/php-cs-fixer": "v3.20.0"
+        "friendsofphp/php-cs-fixer": "v3.21.0"
     }
 }


### PR DESCRIPTION
This looks like being the last php-cs-fixer release that will support PHP 7.4.
There is no problem - in future we can look at running cs-fixer with PHP 8 if we like, even though oC10 core itself has PHP 7.4 for its run-time.