### PR TITLE
Release major version 5 that requires PHP 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] 2023-08-24
+### Changed
+- use latest php-cs-fixer 3.23.0 (requires PHP 8)
+
 ## [4.3.0] 2023-07-14
 ### Changed
 - use latest php-cs-fixer 3.21.0 (the last version that supports PHP 7.4)

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "friendsofphp/php-cs-fixer": "v3.21.0"
+        "friendsofphp/php-cs-fixer": "v3.23.0"
     }
 }


### PR DESCRIPTION
Recent versions of php-cs-fixer require PHP 8.
This PR provides the change to the current php-cs-fixer 3.23.0 which requires PHP 8.
I will make a major version release of `coding-standard` to 5.0.0
That will let anyone get the latest php-cs-fixer release, if they want, but they will need to run PHP 8 to use it.
This might help to get improved coding-style checks. But most of the PHP repos have oC10 core and apps that currently use PHP 7.4. So it will be annoying to deploy the newer version in those - CI can do it easily (have a coding-standard pipeline that uses PHP8), but developers locally could have to switch to PHP 8 to run the coding standard checks, then switch back to PHP 7.4 to run code in oC10 master.