### PR TITLE
chore: bump php-cs-fixer to 3.58.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] 2024-06-01
+### Changed
+- use latest php-cs-fixer 3.58.1 (requires PHP 8)
+
 ## [5.0.0] 2023-08-24
 ### Changed
 - use latest php-cs-fixer 3.23.0 (requires PHP 8)

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "friendsofphp/php-cs-fixer": "v3.23.0"
+        "friendsofphp/php-cs-fixer": "v3.58.1"
     }
 }


### PR DESCRIPTION
so that consumers that are able to use PHP8 can also get the current version of php-cs-fixer.