### PR TITLE
fix: update to spaces_inside_parenthesis rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.2.1] 2024-08-15
+### Changed
+- use spaces_inside_parenthesis rule
+
 ## [5.2.0] 2024-08-15
 ### Changed
 - use latest php-cs-fixer 3.62.0 (requires PHP 8)

--- a/src/Config.php
+++ b/src/Config.php
@@ -50,7 +50,7 @@ class Config extends BaseConfig {
 			'no_break_comment' => true,
 			'no_closing_tag' => true,
 			'no_spaces_after_function_name' => true,
-			'no_spaces_inside_parenthesis' => true,
+			'spaces_inside_parenthesis' => 'none',
 			'no_trailing_whitespace' => true,
 			'no_trailing_whitespace_in_comment' => true,
 			'single_blank_line_at_eof' => true,


### PR DESCRIPTION
php-cs-fixer is reporting:
```
- Rule "no_spaces_inside_parenthesis" is deprecated. Use "spaces_inside_parentheses" instead.
```

Change to using the new rule:
https://cs.symfony.com/doc/rules/whitespace/spaces_inside_parentheses.html
