### PR TITLE
fix: update to spaces_inside_parentheses rule to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.2.3] 2024-08-15
+### Changed
+- set spaces_inside_parentheses rule to true (enabled)
+
 ## [5.2.2] 2024-08-15
 ### Changed
 - use spaces_inside_parentheses rule (fixed spelling)

--- a/src/Config.php
+++ b/src/Config.php
@@ -50,7 +50,7 @@ class Config extends BaseConfig {
 			'no_break_comment' => true,
 			'no_closing_tag' => true,
 			'no_spaces_after_function_name' => true,
-			'spaces_inside_parentheses' => 'none',
+			'spaces_inside_parentheses' => true,
 			'no_trailing_whitespace' => true,
 			'no_trailing_whitespace_in_comment' => true,
 			'single_blank_line_at_eof' => true,


### PR DESCRIPTION
The rule needs to just be enabled (`true`) and the default is already 'none'.
This time I tried it locally on one of the repos. The syntax works. Sorry for publishing so many broken patch versions.