### PR TITLE
fix: replace deprecated 'braces' rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.3.0] 2024-08-15
+### Changed
+- replace deprecated 'braces' rule
+
 ## [5.2.3] 2024-08-15
 ### Changed
 - set spaces_inside_parentheses rule to true (enabled)

--- a/src/Config.php
+++ b/src/Config.php
@@ -34,9 +34,15 @@ class Config extends BaseConfig {
 		$rules = [
 			'@PSR1' => true,
 			// PSR-2
-			'braces' => [
-				'position_after_functions_and_oop_constructs' => 'same'
+			'braces_position' => [
+				'classes_opening_brace' => 'same_line',
+				'functions_opening_brace' => 'same_line'
 			],
+			'control_structure_braces' => true,
+			'control_structure_continuation_position' => true,
+			'declare_parentheses' => true,
+			'no_multiple_statements_per_line' => true,
+			'statement_indentation' => true,
 			'class_definition' => true,
 			'elseif' => true,
 			'encoding' => true,


### PR DESCRIPTION
php-cs-fixer warns:
```
- Rule "braces" is deprecated. Use "single_space_around_construct", "control_structure_braces", "control_structure_continuation_position", "declare_parentheses", "no_multiple_statements_per_line", "braces_position", "statement_indentation" and "no_extra_blank_lines" instead.
```

Our config is still using PSR1 as the base set of rules. Many of these individual 'braces' rules are actually part of PSR2. But some things have not been aligned with PSR2. In particular, our PHP code has the opening brace of a class or function on the same line as the class or function name. PSR2 requires it to go on the next line. Changing our code-base would cause many lines of diffs.

So this PR just removes the deprecated 'braces' rule, and enables the various individual rules that it previously covered.

That gets rid of the "deprecated" warning.