### PR TITLE
Replace visibility_required rule with modifier_keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.3.2] 2026-03-09
+### Changed
+- use at least php-cs-fixer 3.88.0
+
 ## [5.3.1] 2025-08-13
 ### Changed
 - use latest php-cs-fixer 3.85.1 (requires PHP 8)

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "friendsofphp/php-cs-fixer": "^3.85.1"
+        "friendsofphp/php-cs-fixer": "^3.88.0"
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -65,7 +65,7 @@ class Config extends BaseConfig {
 			'single_line_after_imports' => true,
 			'switch_case_semicolon_to_colon' => true,
 			'switch_case_space' => true,
-			'visibility_required' => true,
+			'modifier_keywords' => true,
 			// ownCloud specific
 			'native_function_invocation' => ['strict' => false],
 			'array_syntax' => ['syntax' => 'short'],


### PR DESCRIPTION
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/CHANGELOG.md

feat: rename visibility_required into modifier_keywords (done in v3.88.0 of php-cs-fixer)

To get rid of deprecation message:
Rule "visibility_required" is deprecated. Use "modifier_keywords" instead.